### PR TITLE
fix(webui): limit language list height to 300px with scrollbar

### DIFF
--- a/webui/src/components/TopBar.css
+++ b/webui/src/components/TopBar.css
@@ -73,7 +73,9 @@
   padding: 8px 0;
   z-index: 1000;
   min-width: 200px;
-  overflow: hidden;
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 .menu-item {
   width: 100%;


### PR DESCRIPTION
Prevent language list from overflowing on devices with smaller screens. Add vertical scrollbar for better navigation when list exceeds viewport height.