### PR TITLE
fix: correct ambiguous Chinese locale display names

### DIFF
--- a/webui/src/locales/zh-hant.json
+++ b/webui/src/locales/zh-hant.json
@@ -1,5 +1,5 @@
 {
-  "lang": { "display": "中文" },
+  "lang": { "display": "繁體中文" },
   "common": {
     "appName": "Magic Mount",
     "saving": "保存中...",

--- a/webui/src/locales/zh.json
+++ b/webui/src/locales/zh.json
@@ -1,5 +1,5 @@
 {
-  "lang": { "display": "中文" },
+  "lang": { "display": "简体中文" },
   "common": {
     "appName": "Magic Mount",
     "saving": "保存中...",


### PR DESCRIPTION
The confusion problem of using 'Chinese' for both Simplified and Traditional Chinese has been fixed