### PR TITLE
workflows: adj setup-ndk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Cache NDK
-        id: cache-ndk
-        uses: actions/cache@v5
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
         with:
-          path: ~/ndk_temp
-          key: ndk-${{ runner.os }}-ndk_temp
-      - name: Setup ndk
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
-        run: |
-          ndk_url=$(wget -qO- https://github.com/android/ndk/releases/latest | grep -e 'https://dl.google.com/android/repository/android-ndk-.*-linux.zip' | sed -n 's/.*<a href="\([^"]*\)".*/\1/p')
-          wget -O ndk.zip $ndk_url -nv
-          mkdir -p ~/ndk_temp
-          unzip ndk.zip -d ~/ndk_temp 2>&1 > /dev/null
-          mv ~/ndk_temp/*/* ~/ndk_temp
+          ndk-version: r29
+          add-to-path: true
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -89,8 +80,6 @@ jobs:
           key: ${{ steps.pnpm-cache-restore.outputs.cache-primary-key }}
       - name: Build
         run: |
-          export ANDROID_NDK_HOME=$(realpath ~/ndk_temp)
-          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
           cargo xtask build
       - name: Upload release version
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           ndk-version: r29
           add-to-path: true
+          local-cache: true
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ndk-version: r29
           add-to-path: true
-          local-cache: true
+          local-cache: ${{ github.event_name == 'push' }}
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ndk-version: r29
           add-to-path: true
+          local-cache: true
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Cache NDK
-        id: cache-ndk
-        uses: actions/cache@v5
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
         with:
-          path: ~/ndk_temp
-          key: ndk-${{ runner.os }}-ndk_temp
-      - name: Setup ndk
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
-        run: |
-          ndk_url=$(wget -qO- https://github.com/android/ndk/releases/latest | grep -e 'https://dl.google.com/android/repository/android-ndk-.*-linux.zip' | sed -n 's/.*<a href="\([^"]*\)".*/\1/p')
-          wget -O ndk.zip $ndk_url -nv
-          mkdir -p ~/ndk_temp
-          unzip ndk.zip -d ~/ndk_temp 2>&1 > /dev/null
-          mv ~/ndk_temp/*/* ~/ndk_temp
+          ndk-version: r29
+          add-to-path: true
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Instead of using wget to obtain the NDK, it will be obtained using crate, and if it is a request/request, the NDK in the cache will not be used.