### PR TITLE
chore(ci-bot): fix action filter

### DIFF
--- a/.github/bot/bot.py
+++ b/.github/bot/bot.py
@@ -114,7 +114,7 @@ async def list_workflow_runs(page: int = 1) -> dict:
     logger.info(f"Listing workflow runs (page: {page})")
     return await github_api(
         endpoint="/actions/runs",
-        params={"exclude_pull_requests": True, "page": page, "status": "success"},
+        params={"event": "push", "page": page, "status": "success"},
     )
 
 


### PR DESCRIPTION
Using event=push to filter action runs instead of exclude_pull_requests=true because it didn't meant to filter.