### PR TITLE
adj: adj module description

### DIFF
--- a/src/magic_mount/mod.rs
+++ b/src/magic_mount/mod.rs
@@ -363,6 +363,6 @@ where
     log::info!(
         "mounted files: {mounted_files}, mounted symlinks: {mounted_symbols}, ignored files: {ignored_files}"
     );
-    crate::utils::update_desc()?;
+    crate::utils::update_desc(mounted_files, mounted_symbols, ignored_files)?;
     Ok(())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -101,8 +101,8 @@ where
     }
 }
 
-pub fn update_desc() -> Result<()> {
-    let text = "[😋 Mounted!!]\\nAn implementation of a metamodule using Magic Mount.".to_string();
+pub fn update_desc(file: u32, symbol: u32, ignore: u32) -> Result<()> {
+    let text = format!("[😋 {file},{symbol},{ignore}]\\nAn implementation of a metamodule using Magic Mount.");
 
     let prop = fs::read_to_string(defs::MODULE_PROP)?;
     let mut temp = tempfile::Builder::new().tempfile()?;


### PR DESCRIPTION
I thought of using emojis to indicate that a module has successfully loaded, but 'Mounted' feels a bit illogical, so I replaced it with the content handled by the module.