### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -19,6 +19,8 @@ on:
       - 'Cargo.*'
       - 'build.rs'
       - 'module/**'
+permissions:
+  contents: read
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Tools-cx-app/meta-magic_mount-rs/security/code-scanning/6](https://github.com/Tools-cx-app/meta-magic_mount-rs/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/lints.yml` so all jobs inherit least-privilege defaults unless overridden.  
Best single fix without changing behavior: set:

- `contents: read`

This is sufficient for checkout and lint/format/shellcheck tasks shown, and avoids granting unnecessary write scopes. Place it near the top-level keys (after `on:` block and before `env:` is a clean location).

No imports, methods, or extra definitions are needed (YAML workflow file only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
