### PR TITLE
fix: fix not mirror when use bind custom mount 

### DIFF
--- a/src/bind_mount.rs
+++ b/src/bind_mount.rs
@@ -33,6 +33,7 @@ pub fn bind_mount(umount: bool) -> Result<()> {
         let mut has_mirror = false;
 
         if !target.exists()
+            && target.parent().is_some_and(|p| !p.has_root())
             && let Some(parent) = target.parent()
         {
             for entry in parent.read_dir()?.flatten() {

--- a/src/bind_mount.rs
+++ b/src/bind_mount.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Tools-cx-app <localhost.hutao@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::{fs, path::Path};
 
 use rustix::mount::mount_bind;
 
@@ -32,9 +32,8 @@ pub fn bind_mount(umount: bool) -> Result<()> {
         let workdir = tempfile::Builder::new().tempdir()?;
         let mut has_mirror = false;
 
-        if !target.exists()
-            && target.parent().is_some_and(|p| !p.has_root())
-            && let Some(parent) = target.parent()
+        if let Some(parent) = target.parent()
+            && parent.exists()
         {
             for entry in parent.read_dir()?.flatten() {
                 mount_mirror(parent, workdir.path(), &entry)?;
@@ -47,7 +46,18 @@ pub fn bind_mount(umount: bool) -> Result<()> {
         }
 
         if has_mirror {
-            mount_bind(workdir.path(), target.parent().unwrap())?;
+            // mirror source file to workdir
+            let mirror_target = workdir.path().join(target.file_name().unwrap());
+            if source.is_dir() {
+                fs::create_dir_all(&mirror_target)?;
+            } else {
+                if let Some(p) = mirror_target.parent() {
+                    std::fs::create_dir_all(p)?;
+                }
+                fs::File::create(&mirror_target)?;
+            }
+
+            mount_bind(source, &mirror_target)?;
         } else {
             mount_bind(source, target)?;
         }

--- a/src/bind_mount.rs
+++ b/src/bind_mount.rs
@@ -1,11 +1,14 @@
 // Copyright (C) 2026 Tools-cx-app <localhost.hutao@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
+use std::path::Path;
 
 use rustix::mount::mount_bind;
 
-use crate::{errors::Result, parser::COMMAND_LIST, utils::ksucalls::send_unmountable};
+use crate::{
+    errors::Result, magic_mount::utils::mount_mirror, parser::COMMAND_LIST,
+    utils::ksucalls::send_unmountable,
+};
 
 pub fn bind_mount(umount: bool) -> Result<()> {
     let bind_mount_list: Vec<_> = COMMAND_LIST
@@ -24,12 +27,29 @@ pub fn bind_mount(umount: bool) -> Result<()> {
     for (s, t) in bind_mount_list {
         log::debug!("bind mount: {s} -> {t}");
 
-        if fs::exists(&s).is_err() || fs::exists(&t).is_err() {
+        let source = Path::new(&s);
+        let target = Path::new(&t);
+        let workdir = tempfile::Builder::new().tempdir()?;
+        let mut has_mirror = false;
+
+        if !target.exists()
+            && let Some(parent) = target.parent()
+        {
+            for entry in parent.read_dir()?.flatten() {
+                mount_mirror(parent, workdir.path(), &entry)?;
+                has_mirror = true;
+            }
+        }
+        if !source.exists() || (!target.exists() && !has_mirror) {
             log::error!("source/target isn't existed, skip!!");
             continue;
         }
 
-        mount_bind(&s, &t)?;
+        if has_mirror {
+            mount_bind(workdir.path(), &t)?;
+        } else {
+            mount_bind(&s, &t)?;
+        }
         if umount {
             send_unmountable(&t);
         }

--- a/src/bind_mount.rs
+++ b/src/bind_mount.rs
@@ -46,9 +46,9 @@ pub fn bind_mount(umount: bool) -> Result<()> {
         }
 
         if has_mirror {
-            mount_bind(workdir.path(), &t)?;
+            mount_bind(workdir.path(), target.parent().unwrap())?;
         } else {
-            mount_bind(&s, &t)?;
+            mount_bind(source, target)?;
         }
         if umount {
             send_unmountable(&t);

--- a/src/magic_mount/mod.rs
+++ b/src/magic_mount/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod node;
-mod utils;
+pub mod utils;
 
 use std::{
     fs,


### PR DESCRIPTION
such as directly mount empty folder to `/system`