### PR TITLE
webui: impl auto-apply language

### DIFF
--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -40,13 +40,13 @@ const RebootSummary = t("common.rebootConfirm");
 const rebootreq_click = ref(false);
 
 const pages = [status, config, modules, about];
-const titles = [
+const titles = computed(() => [
   t("tabs.status"),
   t("tabs.config"),
   t("tabs.modules"),
   t("tabs.info"),
-];
-const navItems = titles.map((label) => ({ label }));
+]);
+const navItems = computed(() => titles.value.map((label) => ({ label })));
 const navicoms = [ScreenMirroring, Settings, Folder, Info];
 
 const navindex = ref(0);

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -33,10 +33,6 @@ import { sysStore } from "./lib/stores/sysStore";
 
 const { t } = useI18n();
 
-const Apptitle = t("common.appName");
-const Reboottitle = t("common.rebootTitle");
-const RebootSummary = t("common.rebootConfirm");
-
 const rebootreq_click = ref(false);
 
 const pages = [status, config, modules, about];
@@ -104,7 +100,11 @@ onBeforeUnmount(() => {
 <template>
   <div class="app">
     <MiuixScrollArea ref="scrollerRef" class="app__body">
-      <MiuixTopAppBar :large="false" :title="Apptitle" class="app__top-app-bar">
+      <MiuixTopAppBar
+        :large="false"
+        :title="t('common.appName')"
+        class="app__top-app-bar"
+      >
         <template #actions>
           <MiuixIconButton aria-label="Reboot" @click="rebootreq_click = true">
             <MiuixIcon :icon="Close2" :size="24" />
@@ -132,8 +132,8 @@ onBeforeUnmount(() => {
 
   <MiuixDialog
     v-model="rebootreq_click"
-    :title="Reboottitle"
-    :summary="RebootSummary"
+    :title="t('common.rebootTitle')"
+    :summary="t('common.rebootConfirm')"
     @close="rebootreq_click = false"
   >
     <template #default="{ close }">

--- a/webui/src/page/config.vue
+++ b/webui/src/page/config.vue
@@ -58,8 +58,8 @@ const language_set = computed({
   set: (val: number) => {
     current_lang.value = val;
     switchLocale(lang_code.value[val]);
-  }
-})
+  },
+});
 
 const customMountDraft = ref<CustomMount>({ source: "", target: "" });
 const editingCustomMountIndex = ref<number | null>(null);
@@ -109,8 +109,6 @@ onMounted(async () => {
 
   await configStore.loadConfig();
 });
-
-
 
 function handle_add_partition() {
   configStore.config.partitions.push(partition.value);

--- a/webui/src/page/config.vue
+++ b/webui/src/page/config.vue
@@ -53,6 +53,13 @@ const ignorepath = ref("");
 const current_lang = ref(0);
 
 getCurrentLangIndex().then((index) => (current_lang.value = index));
+const language_set = computed({
+  get: () => current_lang.value,
+  set: (val: number) => {
+    current_lang.value = val;
+    switchLocale(lang_code.value[val]);
+  }
+})
 
 const customMountDraft = ref<CustomMount>({ source: "", target: "" });
 const editingCustomMountIndex = ref<number | null>(null);
@@ -103,10 +110,7 @@ onMounted(async () => {
   await configStore.loadConfig();
 });
 
-async function handleChange(value: number) {
-  await switchLocale(lang_code.value[value]);
-  window.location.reload();
-}
+
 
 function handle_add_partition() {
   configStore.config.partitions.push(partition.value);
@@ -212,19 +216,9 @@ function saveCustomMountDialog() {
     <MiuixCard class="ex-card">
       <MiuixDropdownPreference
         :title="t('common.language')"
-        :summary="lang_code[lang_dropdown_index]"
-        v-model="lang_dropdown_index"
+        v-model="language_set"
         :items="display_list"
       />
-      <div style="padding: 12px">
-        <MiuixButton
-          type="primary"
-          :disabled="lang_dropdown_index === current_lang"
-          @click="handleChange(lang_dropdown_index)"
-        >
-          {{ t("config.apply") }}
-        </MiuixButton>
-      </div>
     </MiuixCard>
 
     <MiuixSmallTitle :text="t('tabs.config')" />


### PR DESCRIPTION
Convert tab titles and nav items to computed properties so UI labels update reactively (e.g., on locale change). In config.vue add a language_set computed getter/setter and bind it to the language dropdown v-model; selecting a language now calls switchLocale immediately. Remove the old handleChange function, the Apply button, and the static summary on the dropdown.