### PR TITLE
ci: directly download cargo-ndk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' }}
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install build dependencies
         run: |
-          cargo install cargo-ndk --locked
+          cargo binstall cargo-ndk
       - name: Setup Webui deps
         run: |
           cd webui/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           node-version: "lts/*"
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-workspace-crates: "true"
+          cache-all-crates: "true"
           save-if: ${{ github.event_name == 'push' }}
       - uses: cargo-bins/cargo-binstall@main
       - name: Install build dependencies


### PR DESCRIPTION
directly download cargo-ndk, don't need rebuild it