### PR TITLE
xtask, webui: set module_id via env

### DIFF
--- a/webui/src/lib/constants.ts
+++ b/webui/src/lib/constants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CONFIG = {
   customMounts: [],
 };
 
-export const module_id = import.meta.env.MODULE_ID
+export const module_id = import.meta.env.MODULE_ID;
 
 export const PATHS = {
   BINARY: "/data/adb/modules/" + module_id + "/meta-mm",

--- a/webui/src/lib/constants.ts
+++ b/webui/src/lib/constants.ts
@@ -11,8 +11,10 @@ export const DEFAULT_CONFIG = {
   customMounts: [],
 };
 
+export const module_id = import.meta.env.MODULE_ID
+
 export const PATHS = {
-  BINARY: "/data/adb/modules/magic_mount_rs/meta-mm",
+  BINARY: "/data/adb/modules/" + module_id + "/meta-mm",
 };
 
 export const BUILTIN_PARTITIONS = [

--- a/webui/src/lib/stores/moduleStore.ts
+++ b/webui/src/lib/stores/moduleStore.ts
@@ -7,10 +7,10 @@ import { ref } from "vue";
 import type { Module } from "../types";
 import { API } from "../api";
 import { uiStore } from "./uiStore";
+import { module_id } from "../constants";
 
 const modules = ref<Module[]>([]);
 const loading = ref(false);
-const mmrs_id = "magic_mount_rs";
 let pendingLoad: Promise<void> | null = null;
 let hasLoaded = false;
 
@@ -46,7 +46,7 @@ function ensureModulesLoaded() {
 
 export const moduleStore = {
   get modules() {
-    return modules.value.filter((module) => module.id != mmrs_id);
+    return modules.value.filter((module) => module.id != module_id);
   },
   get loading() {
     return loading.value;

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -9,7 +9,7 @@ import vue from "@vitejs/plugin-vue";
 let moduleid = process.env.MODULE_ID;
 
 if (!moduleid) {
-  moduleid = "magic_mount_rs";
+  moduleid = "test";
 }
 
 export default defineConfig({

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -6,10 +6,10 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-let moduleid = process.env.MODULE_ID
+let moduleid = process.env.MODULE_ID;
 
 if (!moduleid) {
-  moduleid = "magic_mount_rs"
+  moduleid = "magic_mount_rs";
 }
 
 export default defineConfig({
@@ -20,7 +20,7 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
   },
   define: {
-    'import.meta.env.MODULE_ID': JSON.stringify(moduleid)
+    "import.meta.env.MODULE_ID": JSON.stringify(moduleid),
   },
   plugins: [vue()],
 });

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -6,12 +6,21 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
+let moduleid = process.env.MODULE_ID
+
+if (!moduleid) {
+  moduleid = "magic_mount_rs"
+}
+
 export default defineConfig({
   base: "./",
   build: {
     outDir: "../module/webroot",
     target: "esnext",
     chunkSizeWarningLimit: 1000,
+  },
+  define: {
+    'import.meta.env.MODULE_ID': JSON.stringify(moduleid)
   },
   plugins: [vue()],
 });

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,6 +22,7 @@ use crate::zip_ext::zip_create_from_directory_with_options;
 
 #[derive(Deserialize)]
 struct Package {
+    name: String,
     version: String,
 }
 
@@ -252,7 +253,7 @@ fn match_build(verbose: bool, target: Targets) -> Result<()> {
     let _ = fs::remove_dir_all(&temp_dir);
     let _ = fs::create_dir_all(&temp_dir);
     let _ = fs::create_dir_all(&bin_path);
-    build(verbose, target)?;
+    build(verbose, target, data.package.name)?;
     match target {
         Targets::Arm64 => {
             let arm64_v8a = bin_path.join("arm64-v8a").join("magic_mount_rs");
@@ -363,10 +364,16 @@ fn match_build(verbose: bool, target: Targets) -> Result<()> {
     Ok(())
 }
 
-fn build(verbose: bool, target: Targets) -> Result<()> {
+fn build(verbose: bool, target: Targets, name: String) -> Result<()> {
     let temp_dir = temp_dir();
 
+    unsafe {
+        std::env::set_var("MODULE_ID", name);
+    }
     build_webui()?;
+    unsafe {
+        std::env::remove_var("MODULE_ID");
+    }
 
     let mut cargo = cargo_ndk(target);
     let args = vec![


### PR DESCRIPTION
Expose MODULE_ID to the client via Vite's define and use import.meta.env.MODULE_ID in the web UI. Update PATHS to build the binary path using the configured module id and change moduleStore to filter out that configured module instead of the hard-coded "magic_mount_rs". Default MODULE_ID to "magic_mount_rs" when the environment variable is not set.