### PR TITLE
webui: Centralize navigation index in uiStore

### DIFF
--- a/webui/src/lib/stores/uiStore.ts
+++ b/webui/src/lib/stores/uiStore.ts
@@ -11,6 +11,7 @@ const lang = ref("en");
 const isReady = ref(false);
 const uiStyle = ref<"miuix" | "md3">("miuix");
 const monetEnabled = ref(false);
+const navindex = ref(0);
 
 const availableLanguages = ref<{ code: string; display: string }[]>([]);
 let toastHandler: (text: string) => void = toast;
@@ -39,6 +40,10 @@ function setUiStyle(style: "miuix" | "md3") {
     "miuix-monet",
     style === "miuix" && monetEnabled.value,
   );
+}
+
+function setNavindex(index: number) {
+  navindex.value = index;
 }
 
 function setMonetEnabled(enabled: boolean) {
@@ -89,10 +94,14 @@ export const uiStore = {
   get monetEnabled() {
     return monetEnabled.value;
   },
+  get navindex() {
+    return navindex.value;
+  },
   showToast,
   setToastHandler,
   setLang,
   setUiStyle,
+  setNavindex,
   setMonetEnabled,
   init,
   fetchAvailableLanguages,

--- a/webui/src/ui/md3/App.vue
+++ b/webui/src/ui/md3/App.vue
@@ -5,8 +5,9 @@
 
 -->
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { uiStore } from "../../lib/stores/uiStore";
 import Md3Layout from "./Md3Layout.vue";
 import StatusPage from "./pages/status.vue";
 import ConfigPage from "./pages/config.vue";
@@ -15,7 +16,10 @@ import AboutPage from "./pages/about.vue";
 
 const { t } = useI18n();
 const pages = [StatusPage, ConfigPage, ModulesPage, AboutPage];
-const navindex = ref(0);
+const navindex = computed({
+  get: () => uiStore.navindex,
+  set: (val: number) => uiStore.setNavindex(val),
+});
 const activepage = computed(() => pages[navindex.value]);
 const titles = computed(() => [
   t("tabs.status"),

--- a/webui/src/ui/miuix/App.vue
+++ b/webui/src/ui/miuix/App.vue
@@ -5,7 +5,7 @@
 
 -->
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, onBeforeUnmount } from "vue";
 import { useI18n } from "vue-i18n";
 import { showSnackbar } from "miuix-vue";
 import { uiStore } from "../../lib/stores/uiStore";
@@ -17,7 +17,10 @@ import AboutPage from "./pages/about.vue";
 
 const { t } = useI18n();
 const pages = [StatusPage, ConfigPage, ModulesPage, AboutPage];
-const navindex = ref(0);
+const navindex = computed({
+  get: () => uiStore.navindex,
+  set: (val: number) => uiStore.setNavindex(val),
+});
 const activepage = computed(() => pages[navindex.value]);
 const titles = computed(() => [
   t("tabs.status"),


### PR DESCRIPTION
Move the navigation index into the shared uiStore: add navindex ref and setNavindex setter, and expose it in the store API. Update md3 and miuix App.vue to use a computed binding to uiStore.navindex (get/set) instead of local ref, and remove unused ref imports. This centralizes navigation state for consistent cross-component handling.